### PR TITLE
Sub request controller no longer throws exception

### DIFF
--- a/api_proxy_pbs.info.yml
+++ b/api_proxy_pbs.info.yml
@@ -4,7 +4,7 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 package: "airnet"
 type: module
-version: "1.0.7-alpha"
+version: "1.0.8"
 dependencies:
   - api_proxy
 configure: api_proxy_pbs.settings

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -157,12 +157,14 @@ class ApiController extends ControllerBase
      */
     public function getEpisode($program, $date)
     {
-        return $this->cachedReponse(
-            $this->subRequest(
+        try {
+            $episode = $this->subRequest(
                 "/rest/stations/3pbs/programs/{$program}/episodes/{$date}"
-            ),
-            3600
-        );
+            );
+            return $this->cachedReponse($episode, 3600);
+        } catch (Throwable $e) {
+            return new JsonResponse($e->getMessage());
+        }
     }
 
     /**
@@ -171,11 +173,13 @@ class ApiController extends ControllerBase
      */
     public function getPlaylists($program, $date)
     {
-        return $this->cachedReponse(
-            $this->subRequest(
+        try {
+            $playlist = $this->subRequest(
                 "/rest/stations/3pbs/programs/{$program}/episodes/{$date}/playlists"
-            ),
-            10
-        );
+            );
+            return $this->cachedReponse($playlist, 10);
+        } catch (Throwable $e) {
+            return new JsonResponse($e->getMessage());
+        }
     }
 }

--- a/src/Controller/SubRequestController.php
+++ b/src/Controller/SubRequestController.php
@@ -103,8 +103,6 @@ class SubRequestController extends ControllerBase implements
      * Perform subrequest request with uri.
      * @return json object
      *   The response json.
-     *
-     * @throws \Exception
      */
     public function getJSONSubrequest($uri, $parameters = [])
     {
@@ -127,7 +125,6 @@ class SubRequestController extends ControllerBase implements
             $content = $sub_response->getContent();
             return json_decode($content, true);
         } else {
-            throw new \Exception($sub_response->getContent());
             return [
                 'data' => json_decode($sub_response->getContent(), true),
                 'status' => $code,


### PR DESCRIPTION
It doesn't seem possible to catch Exception thrown by `SubRequestController`.

These changes no longer throw exception, rather than littering Drupal logging with unhandled exceptions. 

#1