### PR TITLE
`ApiController` catches exceptions

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -35,15 +35,6 @@ class ApiController extends ControllerBase
     }
 
     /**
-     * Perform subrequest request with uri
-     * @return json object
-     */
-    protected function subRequest(string $uri, $params = [])
-    {
-        return $this->subRequestController->getJSONSubrequest($uri, $params);
-    }
-
-    /**
      * Return `CacheableJsonResponse` with time to live value headers.
      * @param  Object $data json object
      * @param  Int $ttl time to live in seconds.
@@ -86,7 +77,9 @@ class ApiController extends ControllerBase
     public function getChannel()
     {
         return $this->cachedReponse(
-            $this->subRequest('/rest/stations/3pbs/channels/fm')
+            $this->subRequestController->getJSONSubrequest(
+                '/rest/stations/3pbs/channels/fm'
+            )
         );
     }
 
@@ -97,7 +90,9 @@ class ApiController extends ControllerBase
     public function getSchedule()
     {
         return $this->cachedReponse(
-            $this->subRequest('/rest/stations/3pbs/guides/fm'),
+            $this->subRequestController->getJSONSubrequest(
+                '/rest/stations/3pbs/guides/fm'
+            ),
             86400
         );
     }
@@ -109,7 +104,9 @@ class ApiController extends ControllerBase
     public function getPrograms()
     {
         return $this->cachedReponse(
-            $this->subRequest('/rest/stations/3pbs/programs'),
+            $this->subRequestController->getJSONSubrequest(
+                '/rest/stations/3pbs/programs'
+            ),
             86400
         );
     }
@@ -121,7 +118,9 @@ class ApiController extends ControllerBase
     public function getProgram($program)
     {
         return $this->cachedReponse(
-            $this->subRequest("/rest/stations/3pbs/programs/{$program}"),
+            $this->subRequestController->getJSONSubrequest(
+                "/rest/stations/3pbs/programs/{$program}"
+            ),
             86400
         );
     }
@@ -134,7 +133,7 @@ class ApiController extends ControllerBase
     {
         $params = \Drupal::request()->query->all();
         return $this->cachedReponse(
-            $this->subRequest(
+            $this->subRequestController->getJSONSubrequest(
                 "/rest/stations/3pbs/programs/{$program}/episodes" .
                     '?' .
                     // URL encode params for `api_proxy`
@@ -158,12 +157,20 @@ class ApiController extends ControllerBase
     public function getEpisode($program, $date)
     {
         try {
-            $episode = $this->subRequest(
+            $episode = $this->subRequestController->getJSONSubrequest(
                 "/rest/stations/3pbs/programs/{$program}/episodes/{$date}"
             );
             return $this->cachedReponse($episode, 3600);
-        } catch (Throwable $e) {
-            return new JsonResponse($e->getMessage());
+        } catch (Throwable $t) {
+            return (new JsonResponse([
+                'data' => json_decode($e->getMessage()),
+                'status' => 404,
+            ]))->setStatusCode(404);
+        } catch (\Exception | \Error $e) {
+            return (new JsonResponse([
+                'data' => json_decode($e->getMessage()),
+                'status' => 404,
+            ]))->setStatusCode(404);
         }
     }
 
@@ -174,12 +181,20 @@ class ApiController extends ControllerBase
     public function getPlaylists($program, $date)
     {
         try {
-            $playlist = $this->subRequest(
+            $playlist = $this->subRequestController->getJSONSubrequest(
                 "/rest/stations/3pbs/programs/{$program}/episodes/{$date}/playlists"
             );
             return $this->cachedReponse($playlist, 10);
-        } catch (Throwable $e) {
-            return new JsonResponse($e->getMessage());
+        } catch (Throwable $t) {
+            return (new JsonResponse([
+                'data' => json_decode($e->getMessage()),
+                'status' => 404,
+            ]))->setStatusCode(404);
+        } catch (\Exception | \Error $e) {
+            return (new JsonResponse([
+                'data' => json_decode($e->getMessage()),
+                'status' => 404,
+            ]))->setStatusCode(404);
         }
     }
 }

--- a/src/Controller/SubRequestController.php
+++ b/src/Controller/SubRequestController.php
@@ -142,26 +142,4 @@ class SubRequestController extends ControllerBase implements
             throw new \Exception($e->getMessage());
         }
     }
-
-    /**
-     * Perform request with url
-     * @return json object
-     */
-    protected function getJSON(string $url)
-    {
-        $method = 'GET';
-        $options = [];
-
-        $client = \Drupal::httpClient();
-
-        $response = $client->request($method, $url, $options);
-        $code = $response->getStatusCode();
-
-        if ($code == 200) {
-            $body = $response->getBody()->getContents();
-            return json_decode($body, true);
-        }
-
-        return null;
-    }
 }

--- a/src/Controller/SubRequestController.php
+++ b/src/Controller/SubRequestController.php
@@ -103,6 +103,8 @@ class SubRequestController extends ControllerBase implements
      * Perform subrequest request with uri.
      * @return json object
      *   The response json.
+     *
+     * @throws \Exception
      */
     public function getJSONSubrequest($uri, $parameters = [])
     {
@@ -125,6 +127,7 @@ class SubRequestController extends ControllerBase implements
             $content = $sub_response->getContent();
             return json_decode($content, true);
         } else {
+            throw new \Exception($sub_response->getContent());
             return [
                 'data' => json_decode($sub_response->getContent(), true),
                 'status' => $code,


### PR DESCRIPTION
Currently the api will return a 200 with error message for episode not found:

```
mt@mt-m1 ~ % curl -v --location --request GET 'https://schedule.pbsfm.org.au/api/programs/stardust/episodes/2022-06-20/playlists'

* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Tue, 05 Jul 2022 20:34:02 GMT
< Server: Apache
< Cache-Control: max-age=10, public
< Expires: Tue, 05 Jul 2022 20:34:12 GMT
< X-Drupal-Dynamic-Cache: MISS
< X-UA-Compatible: IE=edge
< Content-language: en
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< Permissions-Policy: interest-cohort=()
< X-Generator: Drupal 9 (https://www.drupal.org)
< X-Drupal-Cache: MISS
< Content-Length: 51
< Content-Type: application/json; charset=utf-8
< 
* Connection #0 to host schedule.pbsfm.org.au left intact
{"data":{"message":"No such episode"},"status":400}%   
```

Change will ensure that 404 is returned for "No such episode"
