### PR TITLE
Rename `ApiController::config` function name.

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -77,11 +77,11 @@ class ApiController extends ControllerBase
     public function getChannel()
     {
         return $this->cachedReponse(
-            $this->config()
+            $this->configuration()
         );
     }
 
-    protected function config()
+    protected function configuration()
     {
         $config = \Drupal::config('api_proxy_pbs.settings');
         $body = $config->get('config');


### PR DESCRIPTION
Possibly issue #8 is due to existing config already defined in https://docs.w3cub.com/drupal~8/core-lib-drupal-core-controller-controllerbase.php/function/controllerbase-config/8.1.x