### PR TITLE
Format 'day' as String

### DIFF
--- a/api_proxy_pbs.info.yml
+++ b/api_proxy_pbs.info.yml
@@ -4,7 +4,7 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 package: "airnet"
 type: module
-version: "1.0.9"
+version: "1.1.0"
 dependencies:
   - api_proxy
 configure: api_proxy_pbs.settings

--- a/src/Controller/ScheduleController.php
+++ b/src/Controller/ScheduleController.php
@@ -143,7 +143,7 @@ class ScheduleController extends ControllerBase
                     $new_program = $programs[$i];
 
                     // Carry existing attributes:
-                    $new_program['day'] = $og_program['day'];
+                    $new_program['day'] = strval($og_program['day']);
                     $new_program['start'] = $og_program['start'];
                     $new_program['duration'] =
                         $og_program['duration'] != null
@@ -167,6 +167,8 @@ class ScheduleController extends ControllerBase
                     unset($og_program['url']);
                     // Set the ISO 8601 date;
                     $og_program['startTime'] = $this->startDate($og_program);
+                    // Replace the 'day' attribute with a string day:
+                    $og_program['day'] = strval($og_program['day']);
 
                     return $og_program;
                     break;


### PR DESCRIPTION
Airnet response 'day' from Airnet appears to now be an `Integer` rather than a `String`.
This is failing the deserialising of the iOS app as the expectation is a `String`.

```json
[
    {
        "guideId": "fm",
        "day": 1,
        "start": "00:00:00",
        "duration": 7200,
        "name": "Spaces Within Space",
        "broadcasters": "Jazz",
        "gridDescription": "Electronic Textures ",
        "slug": "spaceswithin",
        "bannerImage": "https://amrap-pages-image.s3.amazonaws.com/banner/9553.jpg?cacbeb=72188639",
        "bannerImageSmall": "https://amrap-pages-image.s3.amazonaws.com/banner-small/9553.jpg?cacbeb=79875417",
        "profileImage": "https://amrap-pages-image.s3.amazonaws.com/profile/9553.jpg?cacbeb=24111274",
        "profileImageSmall": "https://amrap-pages-image.s3.amazonaws.com/profile-small/9553.jpg?cacbeb=48443329",
        "url": null,
        "onairnow": false
    },
```

These changes reformat the `day` attribute to be a `String` to avoid having to update the app!