### PR TITLE
Update `liveStreamUrlHQ`. 

### DIFF
--- a/api_proxy_pbs.info.yml
+++ b/api_proxy_pbs.info.yml
@@ -3,7 +3,7 @@ description: 'A proxy for Airnet.'
 core_version_requirement: ^9 || ^10
 package: "airnet"
 type: module
-version: "1.1.5"
+version: "1.1.6"
 dependencies:
   - api_proxy
   - symfony/http-client

--- a/src/config.json
+++ b/src/config.json
@@ -2,7 +2,8 @@
   "enableAudioServer": true,
   "enableOnDemandRecording": true,
   "liveStreamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/3PBS_FMAAC.m3u8",
-  "liveStreamUrlHQ": "https://playerservices.streamtheworld.com/api/livestream-redirect/3PBS_FMAAC128.m3u8",
+  "liveStreamUrlHQ": "https://playerservices.streamtheworld.com/api/livestream-redirect/3PBS_FMAACHIGH.m3u8",
+  "liveStreamUrl128": "https://playerservices.streamtheworld.com/api/livestream-redirect/3PBS_FMAAC128.m3u8",
   "browserLiveStreamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/3PBS_FMAAC.m3u8",
   "browserReplayUrlTemplate": "https://airnet.org.au/omnystudio/3pbs/???PROGRAM???/???EPISODE???/aac_mid.m4a",
   "replaySourceUrl": ""


### PR DESCRIPTION
With introduction of 192kbps AAC-LC stream, we need to update the HQ stream. 

>Triton will eventually be disabling the 3PBS_FMAAC128 mount point, so the best thing to do would be to change the HQ stream URL in the streams end point.
